### PR TITLE
Fix plugins not installing via docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,5 +10,5 @@ services:
     restart: unless-stopped
     environment:
         - TZ=America/New_York
-        - APRS_PLUGINS=aprsd-slack-plugin>=1.0.2
+        - APRSD_PLUGINS=aprsd-slack-plugin>=1.0.2
         - LOG_LEVEL=ERROR


### PR DESCRIPTION
Currently the environment variable in the `docker-compose.yml` file does not match the name of the environment variable that `docker/bin/run.sh` expects for installing plugins. Because of this, plugins passed in with the `APRS_PLUGINS` environment variable with docker-compose will not be installed by `docker/bin/run.sh`.

This PR changes the environment variable in the `docker-compose.yml` file from `APRS_PLUGINS` to `APRSD_PLUGINS`. Plugin names passed in via this environment variable are now installed as expected.